### PR TITLE
Get IP list of ZooKeeper nodes from ElasticLoadBalancer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV KAFKA_DIR="/opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}"
 
 RUN apt-get update
 RUN apt-get install wget openjdk-7-jre -y --force-yes
-RUN pip3 install --upgrade kazoo
+RUN pip3 install --upgrade kazoo boto3
 
 ADD download_kafka.sh /tmp/download_kafka.sh
 RUN chmod 777 /tmp/download_kafka.sh
@@ -29,6 +29,7 @@ WORKDIR $KAFKA_DIR
 ADD start_kafka_and_reassign_partitions.py /tmp/start_kafka_and_reassign_partitions.py
 ADD rebalance_partitions.py /tmp/rebalance_partitions.py
 ADD wait_for_kafka_startup.py /tmp/wait_for_kafka_startup.py
+ADD generate_zk_conn_str.py /tmp/generate_zk_conn_str.py
 RUN chmod 777 /tmp/start_kafka_and_reassign_partitions.py
 
 # SCALYR INSTALLATION

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 =====
 Create an autoscaling group in AWS, and on each instance of this autoscaling group, after building the docker image, start Buku like this:
 ```
-sudo docker run -d -e ZOOKEEPER_CONN_STRING=xxx.xxx.xxx.xxx:2181,yyy.yyy.yyy.yyy:2181,zzz.zzz.zzz.zzz:2181 -e JMX_PORT=8004 -p 8004:8004 -p 9092:9092 --net=host <IMAGE_ID>
+sudo docker run -d -e ZOOKEEPER_STACK_NAME=local-test -e JMX_PORT=8004 -p 8004:8004 -p 9092:9092 --net=host <IMAGE_ID>
 ```
 Docker run option ```--net=host``` is needed, so kafka can bind the interface from the host, to listen for leader elections. Ref. https://docs.docker.com/articles/networking/#how-docker-networks-a-container
 
@@ -33,12 +33,12 @@ wget https://raw.githubusercontent.com/zalando/saiki-buku/master/buku.yaml
 ###### execute senza with the definition file
 
 ```
-senza create buku.yaml <STACK_VERSION> <DOCKER_IMAGE_WITH_VERSION_TAG> <MINT_BUCKET> <SCALYR_LOGGING_KEY> <APPLICATION_ID> <ZOOKEEPER_CONN_STRING> <Hosted_Zone> [--region AWS_REGION]
+senza create buku.yaml <STACK_VERSION> <DOCKER_IMAGE_WITH_VERSION_TAG> <MINT_BUCKET> <SCALYR_LOGGING_KEY> <APPLICATION_ID> <ZOOKEEPER_STACK_NAME> <Hosted_Zone> [--region AWS_REGION]
 ```
 
 A real world example would be:
 ```
-senza create buku.yaml 1 pierone.example.org/myteam/buku:0.1-SNAPSHOT example-stups-mint-some_id-eu-west-1 some_scalyr_key buku xxx.xxx.xxx.xxx:2181,yyy.yyy.yyy.yyy:2181,zzz.zzz.zzz.zzz:2181 example.org. --region eu-west-1
+senza create buku.yaml 1 pierone.example.org/myteam/buku:0.1-SNAPSHOT example-stups-mint-some_id-eu-west-1 some_scalyr_key buku zookeeper-stack example.org. --region eu-west-1
 ```
 
 An autoscaling group will be created and Buku docker container will be running on all of the EC2 instances in this autoscaling group.

--- a/buku.yaml
+++ b/buku.yaml
@@ -9,8 +9,8 @@ SenzaInfo:
         Description: "Scalyr Account Key, necessary for Logging."
     - ApplicationID:
         Description: "The Application Id which got registered for buku in Yourturn/Kio."
-    - ZookeeperConnectionString:
-        Description: "Which ZooKeeper Cluster should be used? Format: IP_NODE1:PORT,IP_NODE2:PORT, ... or DNS record and ZooKeeper port of Exhibitor Cluster, e.g.: exhibitor.example.org:2181"
+    - ZookeeperStackName:
+        Description: "Which ZooKeeper Stack should be used?"
     - HostedZone:
         Description: "The generic Hosted Zone for your AWS account"
 SenzaComponents:
@@ -51,7 +51,7 @@ SenzaComponents:
             erase_on_boot: true
             filesystem: ext4
         environment:
-          ZOOKEEPER_CONN_STRING: "{{Arguments.ZookeeperConnectionString}}"
+          ZOOKEEPER_STACK_NAME: "{{Arguments.ZookeeperStackName}}"
           JMX_PORT: 8004
           REASSIGN_PARTITIONS: "yes"
           SCALYR_ACCOUNT_KEY: '{{Arguments.ScalyrAccountKey}}'
@@ -85,7 +85,7 @@ Resources:
             Action: ec2:Describe*
             Resource: "*"
           - Effect: Allow
-            Action: autoscaling:Describe*
+            Action: elasticloadbalancing:Describe*
             Resource: "*"
   BukuSecGroup:
     Type: AWS::EC2::SecurityGroup
@@ -136,9 +136,9 @@ Resources:
       HealthCheck:
         Target: TCP:9092
         Timeout: 5
-        Interval: 30
+        Interval: 60
         UnhealthyThreshold: 2
-        HealthyThreshold: 5
+        HealthyThreshold: 3
       Listeners:
         - InstancePort: 9092
           LoadBalancerPort: 9092

--- a/find_out_own_id.py
+++ b/find_out_own_id.py
@@ -31,6 +31,6 @@ def run():
 
     broker_unique_id = get_broker_unique_id(myid)
     with open(config_file, mode='a', encoding='utf-8') as a_file:
-        a_file.write('broker.id=' + broker_unique_id)
+        a_file.write('broker.id=' + broker_unique_id + '\n')
 
     return broker_unique_id

--- a/generate_zk_conn_str.py
+++ b/generate_zk_conn_str.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import boto3
+import requests
+import os
+
+
+def run(stack_name):
+    url = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
+    private_ips = []
+
+    try:
+        response = requests.get(url)
+        json = response.json()
+        region = json['region']
+
+        elb=boto3.client('elb', region_name=region)
+        ec2 = boto3.client('ec2', region_name=region)
+
+        response = elb.describe_instance_health(LoadBalancerName=stack_name)
+
+        for instance in response['InstanceStates']:
+            if instance['State'] == 'InService':
+                private_ips.append(ec2.describe_instances(InstanceIds=[instance['InstanceId']])['Reservations'][0]['Instances'][0]['PrivateIpAddress'])
+
+    except requests.exceptions.ConnectionError:
+        region = ""
+        instanceId = ""
+        privateIp = "127.0.0.1"
+
+        private_ips = [privateIp]
+
+    zk_conn_str = ''
+    for ip in private_ips:
+        zk_conn_str += ip + ':2181,'
+
+    return zk_conn_str[:-1]

--- a/start_kafka_and_reassign_partitions.py
+++ b/start_kafka_and_reassign_partitions.py
@@ -54,7 +54,9 @@ def check_broker_id_in_zk(broker_id, process):
             os.environ['ZOOKEEPER_CONN_STRING'] = zk_conn_str
             create_broker_properties(zk_conn_str)
             from random import randint
-            sleep(randint(1, 20))
+            wait_to_restart = randint(1, 20)
+            logging.info("Warting " + str(wait_to_restart) + " seconds to restart kafka broker ...")
+            sleep(wait_to_restart)
             process.kill()
             logging.info("Restarting kafka broker with new ZooKeeper connection string ...")
             process = subprocess.Popen([kafka_dir

--- a/start_kafka_and_reassign_partitions.py
+++ b/start_kafka_and_reassign_partitions.py
@@ -7,17 +7,32 @@ import logging
 import find_out_own_id
 from multiprocessing import Pool
 import wait_for_kafka_startup
+import generate_zk_conn_str
 
 kafka_dir = os.getenv('KAFKA_DIR')
 
 logging.basicConfig(level=getattr(logging, 'INFO', None))
 
-f = open(kafka_dir + '/config/server.properties', 'a')
-f.write('\n')
-f.write('zookeeper.connect=' + os.getenv('ZOOKEEPER_CONN_STRING'))
-f.write('\n')
-f.close()
+zk_conn_str = generate_zk_conn_str.run(os.getenv('ZOOKEEPER_STACK_NAME'))
+os.environ['ZOOKEEPER_CONN_STRING'] = zk_conn_str
 
+logging.info("Got ZooKeeper connection string: " + zk_conn_str)
+
+
+def create_broker_properties(zk_conn_str):
+    with open(kafka_dir + '/config/server.properties', "r+") as f:
+        lines = f.read().splitlines()
+        f.seek(0)
+        f.truncate()
+        f.write('zookeeper.connect=' + zk_conn_str + '\n')
+        for line in lines:
+            if not line.startswith("zookeeper.connect"):
+                f.write(line + '\n')
+        f.close()
+
+    logging.info("Broker properties generated with zk connection str: " + zk_conn_str)
+
+create_broker_properties(zk_conn_str)
 broker_id = find_out_own_id.run()
 
 
@@ -25,23 +40,41 @@ def check_broker_id_in_zk(broker_id, process):
     import requests
     from time import sleep
     from kazoo.client import KazooClient
+    zk_conn_str = os.getenv('ZOOKEEPER_CONN_STRING')
     while True:
         if os.getenv('WAIT_FOR_KAFKA') != 'no':
             ip = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document').json()['privateIp']
             wait_for_kafka_startup.run(ip)
             os.environ['WAIT_FOR_KAFKA'] = 'no'
-        zk = KazooClient(hosts=os.getenv('ZOOKEEPER_CONN_STRING'))
+
+        new_zk_conn_str = generate_zk_conn_str.run(os.getenv('ZOOKEEPER_STACK_NAME'))
+        if zk_conn_str != new_zk_conn_str:
+            logging.warning("ZooKeeper connection string changed!")
+            zk_conn_str = new_zk_conn_str
+            os.environ['ZOOKEEPER_CONN_STRING'] = zk_conn_str
+            create_broker_properties(zk_conn_str)
+            from random import randint
+            sleep(randint(1, 20))
+            process.kill()
+            logging.info("Restarting kafka broker with new ZooKeeper connection string ...")
+            process = subprocess.Popen([kafka_dir
+                                        + "/bin/kafka-server-start.sh", kafka_dir
+                                        + "/config/server.properties"])
+            os.environ['WAIT_FOR_KAFKA'] = 'yes'
+            continue
+
+        zk = KazooClient(hosts=zk_conn_str)
         zk.start()
         try:
             zk.get("/brokers/ids/" + broker_id)
             logging.info("I'm still in ZK registered, all good!")
-            sleep(10)
+            sleep(60)
             zk.stop()
         except:
             logging.warning("I'm not in ZK registered, killing kafka broker process!")
             zk.stop()
             process.kill()
-            logging.info("restarting kafka server ...")
+            logging.info("Restarting kafka broker ...")
             process = subprocess.Popen([kafka_dir
                                         + "/bin/kafka-server-start.sh", kafka_dir
                                         + "/config/server.properties"])


### PR DESCRIPTION
generate zookeeper connection string dynamically from zk appliance's ElasticLoadBalancer using its stack name.

so if zookeeper nodes changed then kafka broker will be restarted with a new ip list of zookeeper nodes.
