### PR TITLE
use STACK_NAME as connection string by local test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Usage
 =====
 Create an autoscaling group in AWS, and on each instance of this autoscaling group, after building the docker image, start Buku like this:
 ```
-sudo docker run -d -e ZOOKEEPER_STACK_NAME=local-test -e JMX_PORT=8004 -p 8004:8004 -p 9092:9092 --net=host <IMAGE_ID>
+sudo docker run -d -e ZOOKEEPER_STACK_NAME=localhost -e JMX_PORT=8004 -p 8004:8004 -p 9092:9092 --net=host <IMAGE_ID>
 ```
 Docker run option ```--net=host``` is needed, so kafka can bind the interface from the host, to listen for leader elections. Ref. https://docs.docker.com/articles/networking/#how-docker-networks-a-container
+
+For local test, ```ZOOKEEPER_STACK_NAME``` should be set to the DNS name or IP adresse of one of your ZooKeeper node, such as in this example, ZooKeeper is running on localhost, you can set it with the host alias ```ZOOKEEPER_STACK_NAME=localhost```, or the local loopback IP like ```ZOOKEEPER_STACK_NAME=127.0.0.1```
 
 Deployment with STUPS toolbox
 -----------------------------

--- a/generate_zk_conn_str.py
+++ b/generate_zk_conn_str.py
@@ -24,11 +24,7 @@ def run(stack_name):
                 private_ips.append(ec2.describe_instances(InstanceIds=[instance['InstanceId']])['Reservations'][0]['Instances'][0]['PrivateIpAddress'])
 
     except requests.exceptions.ConnectionError:
-        region = ""
-        instanceId = ""
-        privateIp = "127.0.0.1"
-
-        private_ips = [privateIp]
+        private_ips = [stack_name]
 
     zk_conn_str = ''
     for ip in private_ips:


### PR DESCRIPTION
This new change enables local test without AWS and STUPS environment.

```ZOOKEEPER_STACK_NAME``` will be took as IP of local running zookeeper node.