### PR TITLE
Add kafka health health check to the appliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,12 @@ ADD start_kafka_and_reassign_partitions.py /tmp/start_kafka_and_reassign_partiti
 ADD rebalance_partitions.py /tmp/rebalance_partitions.py
 ADD wait_for_kafka_startup.py /tmp/wait_for_kafka_startup.py
 ADD generate_zk_conn_str.py /tmp/generate_zk_conn_str.py
+ADD zookeeper.py /tmp/zookeeper.py
+ADD health.py /tmp/health.py
 RUN chmod 777 /tmp/start_kafka_and_reassign_partitions.py
 
 ADD scm-source.json /scm-source.json
 
 CMD /usr/bin/env python3 -u /tmp/start_kafka_and_reassign_partitions.py
 
-EXPOSE 9092 8004
+EXPOSE 9092 8004 8080

--- a/buku.yaml
+++ b/buku.yaml
@@ -40,6 +40,7 @@ SenzaComponents:
         ports:
           9092: 9092
           8004: 8004
+          8080: 8080
         scalyr_account_key: '{{Arguments.ScalyrAccountKey}}'
         networking: host
         enhanced_cloudwatch_metrics: true
@@ -48,6 +49,7 @@ SenzaComponents:
         logs:
           /opt/kafka_2.10-0.8.2.1/logs/
         environment:
+          EXHIBITOR_HOST: "{{Arguments.ZookeeperStackName}}.{{Arguments.HostedZone}}"
           ZOOKEEPER_STACK_NAME: "{{Arguments.ZookeeperStackName}}"
           ZOOKEEPER_PREFIX: "{{Arguments.ZookeeperPrefix}}"
           JMX_PORT: 8004
@@ -94,6 +96,10 @@ Resources:
         - IpProtocol: tcp
           FromPort: 8004
           ToPort: 8004
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
           CidrIp: "0.0.0.0/0"
         - IpProtocol: tcp
           FromPort: 22
@@ -145,6 +151,10 @@ Resources:
           InstanceProtocol: TCP
         - InstancePort: 8004
           LoadBalancerPort: 8004
+          Protocol: TCP
+          InstanceProtocol: TCP
+        - InstancePort: 8080
+          LoadBalancerPort: 8080
           Protocol: TCP
           InstanceProtocol: TCP
       SecurityGroups:

--- a/health.py
+++ b/health.py
@@ -1,0 +1,61 @@
+import fcntl
+import json
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+from threading import Thread
+from kazoo.exceptions import NoNodeError
+from zookeeper import get_zookeeper
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(self.server.get_bad_brokers()).encode('utf-8'))
+
+
+class HealthServer(ThreadingMixIn, HTTPServer, Thread):
+
+    def __init__(self):
+        HTTPServer.__init__(self, ('0.0.0.0', 8080), HealthHandler)
+        Thread.__init__(self, target=self.serve_forever)
+        self._set_fd_cloexec(self.socket)
+        self.zk = get_zookeeper()
+        self.daemon = True
+        self._fetch_brokers = True
+        self._bad_brokers = []
+
+    def _brokers_watcher(self, event):
+        self._fetch_brokers = True
+
+    def _get_brokers(self):
+        return self.zk.get_children('/brokers/ids', self._brokers_watcher)
+
+    def _get_bad_brokers(self, good_brokers):
+        bad_brokers = set()
+        good_brokers = set(map(int, good_brokers))
+        for topic in self.zk.get_children('/brokers/topics'):
+            try:
+                details = json.loads(self.zk.get('/brokers/topics/' + topic)[0].decode('utf-8'))
+                for partition, brokers in details['partitions'].items():
+                    for broker in brokers:
+                        if broker not in good_brokers:
+                            bad_brokers.add(broker)
+            except NoNodeError:
+                pass
+        return list(bad_brokers)
+
+    def get_bad_brokers(self):
+        if self._fetch_brokers:
+            brokers = self._get_brokers()
+            self._bad_brokers = self._get_bad_brokers(brokers)
+            self._fetch_brokers = False
+        return self._bad_brokers
+
+    @staticmethod
+    def _set_fd_cloexec(fd):
+        flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+        fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)

--- a/start_kafka_and_reassign_partitions.py
+++ b/start_kafka_and_reassign_partitions.py
@@ -10,6 +10,8 @@ from multiprocessing import Pool
 import wait_for_kafka_startup
 import generate_zk_conn_str
 
+from health import HealthServer
+
 kafka_dir = os.getenv('KAFKA_DIR')
 
 logging.basicConfig(level=getattr(logging, 'INFO', None))
@@ -101,6 +103,8 @@ def check_broker_id_in_zk(broker_id, process):
                                         + "/bin/kafka-server-start.sh", kafka_dir
                                         + "/config/server.properties"])
             os.environ['WAIT_FOR_KAFKA'] = 'yes'
+
+HealthServer().start()
 
 pool = Pool()
 

--- a/zookeeper.py
+++ b/zookeeper.py
@@ -1,0 +1,98 @@
+import logging
+import os
+import random
+import requests
+import time
+
+from kazoo.client import KazooClient
+from kazoo.exceptions import NoNodeError
+from requests.exceptions import RequestException
+
+logger = logging.getLogger(__name__)
+
+
+class ExhibitorEnsembleProvider:
+
+    TIMEOUT = 3.1
+
+    def __init__(self, hosts, port, uri_path='/exhibitor/v1/cluster/list', poll_interval=300):
+        self._exhibitor_port = port
+        self._uri_path = uri_path
+        self._poll_interval = poll_interval
+        self._exhibitors = hosts
+        self._master_exhibitors = hosts
+        self._zookeeper_hosts = ''
+        self._next_poll = None
+        while not self.poll():
+            logger.info('waiting on exhibitor')
+            time.sleep(5)
+
+    def poll(self):
+        if self._next_poll and self._next_poll > time.time():
+            return False
+
+        json = self._query_exhibitors(self._exhibitors)
+        if not json:
+            json = self._query_exhibitors(self._master_exhibitors)
+
+        if isinstance(json, dict) and 'servers' in json and 'port' in json:
+            self._next_poll = time.time() + self._poll_interval
+            zookeeper_hosts = ','.join([h + ':' + str(json['port']) for h in sorted(json['servers'])])
+            if self._zookeeper_hosts != zookeeper_hosts:
+                logger.info('ZooKeeper connection string has changed: %s => %s', self._zookeeper_hosts, zookeeper_hosts)
+                self._zookeeper_hosts = zookeeper_hosts
+                self._exhibitors = json['servers']
+                return True
+        return False
+
+    def _query_exhibitors(self, exhibitors):
+        random.shuffle(exhibitors)
+        for host in exhibitors:
+            uri = 'http://{}:{}{}'.format(host, self._exhibitor_port, self._uri_path)
+            try:
+                response = requests.get(uri, timeout=self.TIMEOUT)
+                return response.json()
+            except RequestException:
+                pass
+        return None
+
+    @property
+    def zookeeper_hosts(self):
+        return self._zookeeper_hosts
+
+
+class Exhibitor:
+
+    def __init__(self, exhibitor, chroot):
+        self.chroot = chroot
+        self.exhibitor = ExhibitorEnsembleProvider(exhibitor['hosts'], exhibitor['port'], poll_interval=30)
+        self.client = KazooClient(hosts=self.exhibitor.zookeeper_hosts + self.chroot,
+                                  command_retry={
+                                      'deadline': 10,
+                                      'max_delay': 1,
+                                      'max_tries': -1},
+                                  connection_retry={'max_delay': 1, 'max_tries': -1})
+        self.client.add_listener(self.session_listener)
+        self.client.start()
+
+    def session_listener(self, state):
+        pass
+
+    def _poll_exhibitor(self):
+        if self.exhibitor.poll():
+            self.client.set_hosts(self.exhibitor.zookeeper_hosts)
+
+    def get(self, *params):
+        self._poll_exhibitor()
+        return self.client.retry(self.client.get, *params)
+
+    def get_children(self, *params):
+        self._poll_exhibitor()
+        try:
+            return self.client.retry(self.client.get_children, *params)
+        except NoNodeError:
+            return []
+
+
+def get_zookeeper():
+    return Exhibitor({'hosts': [os.getenv('EXHIBITOR_HOST')], 'port': 8181}, os.getenv('ZOOKEEPER_PREFIX'))


### PR DESCRIPTION
Health check simply checks that there are not partitions which are
stored on brokers which are not registered in zookeeper.
As a result it returns array of "dead broker" id's.
If there are no dead brokers array would be empty.

Usage: curl http://buku-<stack-version>.<team-name>.zalan.do:8080