### PR TITLE
Feature/ec2

### DIFF
--- a/buku.yaml
+++ b/buku.yaml
@@ -20,12 +20,12 @@ SenzaComponents:
         Minimum: 3
         Maximum: 3
         MetricType: CPU
-      HealthCheckType: ELB
+      HealthCheckType: EC2
       ElasticLoadBalancer: AppLoadBalancer
       LoadBalancerNames:
         - Ref: AppLoadBalancer
       BlockDeviceMappings:
-        - DeviceName: /dev/sda1
+        - DeviceName: /dev/xvdk
           Ebs:
             VolumeSize: 500
             VolumeType: gp2
@@ -52,6 +52,12 @@ SenzaComponents:
           ZOOKEEPER_PREFIX: "{{Arguments.ZookeeperPrefix}}"
           JMX_PORT: 8004
           REASSIGN_PARTITIONS: "yes"
+        mounts:
+          /data:
+            partition: /dev/xvdk
+            filesystem: ext4
+            erase_on_boot: true
+            options: noatime,nodiratime,nobarrier
 Resources:
   BukuRole:
     Type: AWS::IAM::Role

--- a/start_kafka_and_reassign_partitions.py
+++ b/start_kafka_and_reassign_partitions.py
@@ -115,7 +115,8 @@ if os.getenv('REASSIGN_PARTITIONS') == 'yes':
 logging.info("starting kafka server ...")
 os.environ['KAFKA_OPTS'] = "-server " \
                            + "-Dlog4j.configuration=file:" + kafka_dir + "/config/log4j.properties " \
-                           + "-javaagent:/tmp/jolokia-jvm-" + os.getenv('JOLOKIA_VERSION') + "-agent.jar=host=0.0.0.0"
+                           + "-javaagent:/tmp/jolokia-jvm-" + os.getenv('JOLOKIA_VERSION') + "-agent.jar=host=0.0.0.0" \
+                           + " -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=32M"
 # + "-Xmx512M " \
 os.environ['KAFKA_JMX_OPTS'] = "-Dcom.sun.management.jmxremote=true " \
                                + "-Dcom.sun.management.jmxremote.authenticate=false " \

--- a/tail_logs_and_start.sh
+++ b/tail_logs_and_start.sh
@@ -2,14 +2,14 @@
 
 touch -f $KAFKA_DIR/logs/controller.log
 #touch -f $KAFKA_DIR/logs/server.log
-touch -f $KAFKA_DIR/logs/kafkaServer-gc.log 
+#touch -f $KAFKA_DIR/logs/kafkaServer-gc.log 
 touch -f $KAFKA_DIR/logs/log-cleaner.log
 touch -f $KAFKA_DIR/logs/kafka-request.log
 touch -f $KAFKA_DIR/logs/state-change.log
 
 tail -f $KAFKA_DIR/logs/controller.log &
 #tail -f $KAFKA_DIR/logs/server.log &
-tail -f $KAFKA_DIR/logs/kafkaServer-gc.log &
+#tail -f $KAFKA_DIR/logs/kafkaServer-gc.log &
 tail -f $KAFKA_DIR/logs/log-cleaner.log &
 tail -f $KAFKA_DIR/logs/kafka-request.log &
 tail -f $KAFKA_DIR/logs/state-change.log &


### PR DESCRIPTION
Set HealthCheckType to EC2 to prevent instance termination and data loss when the kafka is not running.
In addition to that move kafka-logs to the separate EBS device.

All this actions are needed to avoid problems when the kafka dies due to running out of disk space.