### PR TITLE
Run start_kafka_and_reassign_partitions.py with pid=1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,6 @@ ADD scm-source.json /scm-source.json
 ADD tail_logs_and_start.sh /tmp/tail_logs_and_start.sh
 RUN chmod 777 /tmp/tail_logs_and_start.sh
 
-CMD /tmp/tail_logs_and_start.sh
+ENTRYPOINT ["/bin/bash", "/tmp/tail_logs_and_start.sh"]
 
 EXPOSE 9092 8004 8080

--- a/rebalance_partitions.py
+++ b/rebalance_partitions.py
@@ -105,9 +105,7 @@ def generate_json(zk_dict, topics_to_reassign="all"):
     logging.debug("topics_to_reassign:")
     logging.debug(topics_to_reassign)
 
-    tmp_topic_dict = {}
-    for tmp_topic in zk_dict['topics']:
-        tmp_topic_dict[tmp_topic['name']] = tmp_topic['partitions']
+    tmp_topic_dict = {t['name']: t['partitions'] for t in zk_dict['topics']}
 
     if len(topics_to_reassign) > 0:
         logging.info("topics_to_reassign found, generating new assignment pattern")

--- a/tail_logs_and_start.sh
+++ b/tail_logs_and_start.sh
@@ -14,4 +14,4 @@ tail -f $KAFKA_DIR/logs/log-cleaner.log &
 tail -f $KAFKA_DIR/logs/kafka-request.log &
 tail -f $KAFKA_DIR/logs/state-change.log &
 
-/usr/bin/env python3 -u /tmp/start_kafka_and_reassign_partitions.py
+exec /usr/bin/env python3 -u /tmp/start_kafka_and_reassign_partitions.py


### PR DESCRIPTION
This is necessary to to be able to catch sigterm and forward it to the kafka to enable clean shutdown.