### PR TITLE
Calculate replication factor for the whole topic instead of single partition

### DIFF
--- a/rebalance_partitions.py
+++ b/rebalance_partitions.py
@@ -1,6 +1,6 @@
 from kazoo.client import KazooClient, KazooState, NodeExistsError, NoNodeError
 from time import sleep
-import collections
+from collections import Counter
 import logging
 import json
 import os
@@ -135,7 +135,8 @@ def generate_json(zk_dict, topics_to_reassign="all", target_brokers="all"):
         logging.info("generating now ")
         weights = get_broker_weights(zk_dict, avail_brokers_init, ignore_existing)
         for topic, partitions in topics_to_reassign.items():
-            replication_factor = collections.Counter(map(len, tmp_topic_dict[topic].values())).most_common(1)[0][0]
+            counter = Counter(map(len, tmp_topic_dict[topic].values()))
+            replication_factor = sorted(sorted(counter.items()), key=lambda e: e[1], reverse=True)[0][0]
 
             logging.debug("Available Brokers: %s", len(avail_brokers_init))
             logging.debug("Replication Factor: %s", replication_factor)

--- a/rebalance_partitions.py
+++ b/rebalance_partitions.py
@@ -136,7 +136,7 @@ def generate_json(zk_dict, topics_to_reassign="all", target_brokers="all"):
         weights = get_broker_weights(zk_dict, avail_brokers_init, ignore_existing)
         for topic, partitions in topics_to_reassign.items():
             counter = Counter(map(len, tmp_topic_dict[topic].values()))
-            replication_factor = sorted(sorted(counter.items()), key=lambda e: e[1], reverse=True)[0][0]
+            replication_factor = sorted(counter.items(), key=lambda e: e[1])[0][0]
 
             logging.debug("Available Brokers: %s", len(avail_brokers_init))
             logging.debug("Replication Factor: %s", replication_factor)


### PR DESCRIPTION
Couple of times we had situations when there were 4 brokers assigned for
one partition. It has happened when one of the kafka nodes was
terminated while another node was doing rebalancing. New node was not
able to start rebalancing because NotEnoughBrokersException was raised
and process of rebalancing didn't even started.
As a simple workaround of such situation we must calculate replication
factor for all partitions of one topic and choose most common value.

Example: {'0': [1,2,3], '1': [1,2,3], '2': [1,2,3,4], '3': [2,3,4]}
replication factor for all partitions must be 3, because there are 3
partitions with replication factor 3 and only one with replication
factor 4.