### PR TITLE
Forgotten chroot (zookeeper_prefix) when updating list of nodes

### DIFF
--- a/zookeeper.py
+++ b/zookeeper.py
@@ -80,7 +80,7 @@ class Exhibitor:
 
     def _poll_exhibitor(self):
         if self.exhibitor.poll():
-            self.client.set_hosts(self.exhibitor.zookeeper_hosts)
+            self.client.set_hosts(self.exhibitor.zookeeper_hosts + self.chroot)
 
     def get(self, *params):
         self._poll_exhibitor()


### PR DESCRIPTION
Basically this error was not critical because Kafka anyway needs to be restarted.