### PR TITLE
health server port now configurable via HEALTH_SERVER_PORT env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV KAFKA_DIR="/opt/kafka"
 ENV SERVER_PROPERTIES="https://raw.githubusercontent.com/zalando/saiki-buku/master/server.properties"
 ENV LOG4J_PROPERTIES="https://raw.githubusercontent.com/zalando/saiki-buku/master/log4j.properties"
 
+ENV HEALTH_SERVER_PORT=${HEALTH_SERVER_PORT:-8080}
+
 RUN apt-get update
 RUN apt-get install wget openjdk-7-jre -y --force-yes
 RUN pip3 install --upgrade kazoo boto3
@@ -46,4 +48,5 @@ RUN chmod 777 /tmp/tail_logs_and_start.sh
 
 ENTRYPOINT ["/bin/bash", "/tmp/tail_logs_and_start.sh"]
 
-EXPOSE 9092 8004 8080
+EXPOSE 9092 8004 ${HEALTH_SERVER_PORT}
+

--- a/health.py
+++ b/health.py
@@ -2,6 +2,7 @@ import fcntl
 import json
 import time
 
+from os import getenv
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from threading import Thread
@@ -21,7 +22,7 @@ class HealthHandler(BaseHTTPRequestHandler):
 class HealthServer(ThreadingMixIn, HTTPServer, Thread):
 
     def __init__(self):
-        HTTPServer.__init__(self, ('0.0.0.0', 8080), HealthHandler)
+        HTTPServer.__init__(self, ('0.0.0.0', int(getenv('HEALTH_SERVER_PORT'))), HealthHandler)
         Thread.__init__(self, target=self.serve_forever)
         self._set_fd_cloexec(self.socket)
         self.zk = get_zookeeper()


### PR DESCRIPTION
to prevent port conflicts between multiple containers that require the --net=host switch