### PR TITLE
Expose KAFKA_HEAP_OPTS environment variable

### DIFF
--- a/buku.yaml
+++ b/buku.yaml
@@ -11,6 +11,9 @@ SenzaInfo:
         Description: "Which ZooKeeper node should be used as prefix?"
     - HostedZone:
         Description: "The generic Hosted Zone for your AWS account"
+    - KafkaHeapOpts:
+        Description: "JVM options for Kafka process"
+        Default: ""
 SenzaComponents:
   - Configuration:
       Type: Senza::StupsAutoConfiguration
@@ -53,6 +56,7 @@ SenzaComponents:
           ZOOKEEPER_PREFIX: "{{Arguments.ZookeeperPrefix}}"
           JMX_PORT: 8004
           REASSIGN_PARTITIONS: "yes"
+          KAFKA_HEAP_OPTS: "{{Arguments.KafkaHeapOpts}}"
         mounts:
           /data:
             partition: /dev/xvdk


### PR DESCRIPTION
Users deploying Kafka on large machines could be interested in fine tunning `Xmx` and `Xms` JVM options.